### PR TITLE
Fixing issue #19 with unit-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .DS_Store
 test/test_repo
+*.js
+*.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+test/test_repo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against this version of Node.js
+environment:
+  nodejs_version: "6.2.0"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test -- -t 10000
+
+# Don't actually build.
+build: off

--- a/lib/hg-repository.coffee
+++ b/lib/hg-repository.coffee
@@ -421,7 +421,7 @@ class HgRepository
   # updates the relevant properties.
   refreshStatus: ->
     new Promise((resolve, reject) =>
-      @cachedIgnoreStatuses = @getRepo().getRecursiveIgnoreStatuses()
+      @cachedIgnoreStatuses = (@slashPath ignored for ignored in @getRepo().getRecursiveIgnoreStatuses())
 
       statusesDidChange = false
       if @getRepo().checkRepositoryHasChanged()

--- a/lib/hg-repository.coffee
+++ b/lib/hg-repository.coffee
@@ -31,10 +31,10 @@ class HgRepository
   constructor: (path, options={}) ->
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
-
     @repo = HgUtils.open(path)
+
     unless @repo?
-      throw new Error("No Mercurial repository found searching path: #{path.path}")
+      throw new Error("No Mercurial repository found searching path: #{path}")
 
     # asyncOptions = _.clone(options)
     @async = HgRepositoryAsync.open(path, options)

--- a/lib/hg-repository.coffee
+++ b/lib/hg-repository.coffee
@@ -438,4 +438,5 @@ class HgRepository
           statusesDidChange = true
 
       if statusesDidChange then @emitter.emit 'did-change-statuses'
+      resolve()
     )

--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -67,6 +67,9 @@ class Repository
       @binaryAvailable = false
     return @binaryAvailable
 
+  exists: () ->
+    return fs.existsSync(@rootPath + '/.hg')
+
   # Parses info from `hg info` and `hgversion` command and checks if repo infos have changed
   # since last check
   #
@@ -453,7 +456,7 @@ exports.isStatusStaged = (status) ->
 # Returns a new {Repository} object
 openRepository = (repositoryPath) ->
   repository = new Repository(repositoryPath)
-  if repository.checkBinaryAvailable()
+  if repository.checkBinaryAvailable() and repository.exists()
     return repository
   else
     return null

--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -248,7 +248,7 @@ class Repository
 
     return '' unless @isCommandForRepo(params)
 
-    child = spawnSync('hg', params)
+    child = spawnSync('hg', params, { cwd: @rootPath })
     if child.status != 0
       if child.stderr
         throw new Error(child.stderr.toString())
@@ -296,7 +296,7 @@ class Repository
   # Returns a {Array} with path and statusnumber
   getRecursiveIgnoreStatuses: () ->
     try
-      files = @hgCommand(['status', @rootPath])
+      files = @hgCommand(['status', @rootPath, "-A"])
     catch error
       @handleHgError(error)
       return []
@@ -312,7 +312,7 @@ class Repository
           if (status is 'I') # || status is '?')
             items.push(pathPart.replace('..', ''))
 
-    return items
+    (path.join @rootPath, item for item in items)
 
   # Returns on success an hg-status array. Otherwise null.
   # Array keys are paths, values {Number} representing the status

--- a/package.json
+++ b/package.json
@@ -23,5 +23,13 @@
         "0.1.0": "getRepositoryProviderService"
       }
     }
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "coffee-script": "^1.10.0",
+    "mocha": "^3.0.2"
+  },
+  "scripts": {
+    "test": "mocha --compilers coffee:coffee-script/register"
   }
 }

--- a/test/empty_repo.coffee
+++ b/test/empty_repo.coffee
@@ -4,11 +4,12 @@ HgRepository = require '../lib/hg-repository'
 TestRepository = require './testRepository'
 assert = require('chai').assert
 
-testRepo = new TestRepository 'empty_repo'
-before ->
-  testRepo.init()
-
 describe 'Constructing hg-repository', ->
+  testRepo = new TestRepository 'empty_repo'
+
+  before ->
+    testRepo.init()
+
   it 'should throw exception on nonexisting repository', ->
     assert.throws ->
       repo = new HgRepository (testRepo.fullPath() + "_not_exists")
@@ -18,5 +19,5 @@ describe 'Constructing hg-repository', ->
     repo = new HgRepository testRepo.fullPath()
     assert.ok repo
 
-after ->
-  testRepo.destroy()
+  after ->    
+    testRepo.destroy()

--- a/test/empty_repo.coffee
+++ b/test/empty_repo.coffee
@@ -1,0 +1,22 @@
+require 'coffee-script/register'
+require './fakeWindow'
+HgRepository = require '../lib/hg-repository'
+TestRepository = require './testRepository'
+assert = require('chai').assert
+
+testRepo = new TestRepository 'empty_repo'
+before ->
+  testRepo.init()
+
+describe 'Constructing hg-repository', ->
+  it 'should throw exception on nonexisting repository', ->
+    assert.throws ->
+      repo = new HgRepository (testRepo.fullPath() + "_not_exists")
+    , 'No Mercurial repository found searching path: ' + testRepo.fullPath()
+
+  it 'should create a repo from an empty repository', ->
+    repo = new HgRepository testRepo.fullPath()
+    assert.ok repo
+
+after ->
+  testRepo.destroy()

--- a/test/empty_repo.ps1
+++ b/test/empty_repo.ps1
@@ -1,0 +1,1 @@
+hg init $args[0]

--- a/test/empty_repo.sh
+++ b/test/empty_repo.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd "${0%/*}"
+mkdir $1
+cd $1
+hg init

--- a/test/empty_repo.sh
+++ b/test/empty_repo.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-cd "${0%/*}"
-mkdir $1
-cd $1
-hg init
+hg init $1

--- a/test/fakeWindow.coffee
+++ b/test/fakeWindow.coffee
@@ -1,0 +1,4 @@
+global.window = {
+    addEventListener: ()->
+    removeEventListener: ()->
+}

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -27,7 +27,8 @@ describe 'In a repo with some ignored files', ->
   describe 'with a tracked file', ->
     clean_file = path.join testRepo.fullPath(), 'clean_file'
     it 'should return isPathIgnored false', ->
-      assert.equal(repo.isPathIgnored(clean_file), false)
+      repo.refreshStatus().then ->
+        assert.equal(repo.isPathIgnored(clean_file), false)
 
-  after ->    
+  after ->
     testRepo.destroy()

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -1,0 +1,33 @@
+require 'coffee-script/register'
+require './fakeWindow'
+HgRepository = require '../lib/hg-repository'
+TestRepository = require './testRepository'
+assert = require('chai').assert
+path = require 'path'
+
+describe 'In a repo with some ignored files', ->
+  testRepo = new TestRepository path.parse(__filename).name
+  repo = null
+  before ->
+    testRepo.init()
+
+  beforeEach ->
+    repo = new HgRepository testRepo.fullPath()
+
+  describe 'with an ignored file', ->
+    ignored_file = path.join testRepo.fullPath(), 'ignored_file'
+
+    it 'should return isPathIgnored true', ->
+      repo.refreshStatus().then ->
+        assert.equal(repo.isPathIgnored(ignored_file), true)
+
+    it 'should return getPathStatus 0', ->
+      assert.equal(repo.getPathStatus(ignored_file), 0)
+
+  describe 'with a tracked file', ->
+    clean_file = path.join testRepo.fullPath(), 'clean_file'
+    it 'should return isPathIgnored false', ->
+      assert.equal(repo.isPathIgnored(clean_file), false)
+
+  after ->    
+    testRepo.destroy()

--- a/test/simple_repo.ps1
+++ b/test/simple_repo.ps1
@@ -1,0 +1,21 @@
+hg init $args[0]
+set-location $args[0]
+
+("clean_file", "modified_file", "removed_file", "missing_file") | foreach-object {
+  new-item -type File $_
+  hg add $_
+}
+
+new-item -type File "untracked_file"
+new-item -type File "ignored_file"
+
+Set-Content -Path ".hgignore" -Value @"
+syntax:glob
+ignored_file
+"@
+hg add ".hgignore"
+
+hg commit -m "Commit 1" -u "Tester <test@test.com>"
+Set-Content -Path "modified_file" -Value "Changes!"
+hg remove "removed_file"
+Remove-Item "missing_file"

--- a/test/simple_repo.sh
+++ b/test/simple_repo.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+hg init $1
+cd $1
+
+files=("clean_file" "modified_file" "removed_file" "missing_file")
+for f in ${files[*]}
+do
+  touch $f
+  hg add $f
+done
+touch "untracked_file"
+touch "ignored_file"
+
+echo -e "syntax:glob\nignored_file">".hgignore"
+hg add ".hgignore"
+
+hg commit -m "Commit 1" -u "Tester <test@test.com>"
+echo -e "Changes!">"modified_file"
+hg remove "removed_file"
+rm "missing_file"

--- a/test/testRepository.coffee
+++ b/test/testRepository.coffee
@@ -1,15 +1,24 @@
 path = require 'path'
-process = require 'child_process'
+exec = require('child_process').execSync
 
 module.exports =
   class TestRepository
+    isWindows = process.platform == 'win32'
+    extension = if isWindows then '.ps1' else '.sh'
+
     constructor: (@scenario) ->
 
     init: ->
-      process.execSync path.join __dirname, @scenario + '.sh' + ' ' + @fullPath()
+      if isWindows
+        exec 'powershell -file ' + path.join __dirname, @scenario + extension + ' ' + @fullPath()
+      else
+        exec path.join __dirname, @scenario + extension + ' ' + @fullPath()
 
     fullPath: ->
       path.join __dirname, 'test_repo'
 
     destroy: ->
-      process.execSync 'rm -rf ' + @fullPath()
+      if isWindows        
+        exec 'powershell -command "remove-item -recurse -force ' + @fullPath() + '"'
+      else
+        exec 'rm -rf ' + @fullPath()

--- a/test/testRepository.coffee
+++ b/test/testRepository.coffee
@@ -1,4 +1,5 @@
 path = require 'path'
+fs = require 'fs'
 exec = require('child_process').execSync
 
 module.exports =
@@ -9,6 +10,8 @@ module.exports =
     constructor: (@scenario) ->
 
     init: ->
+      if @exists()
+        @destroy()
       if isWindows
         exec 'powershell -file ' + path.join __dirname, @scenario + extension + ' ' + @fullPath()
       else
@@ -17,8 +20,11 @@ module.exports =
     fullPath: ->
       path.join __dirname, 'test_repo'
 
-    destroy: ->
-      if isWindows        
+    exists: () ->
+      fs.existsSync(@fullPath)
+
+    destroy: ->      
+      if isWindows
         exec 'powershell -command "remove-item -recurse -force ' + @fullPath() + '"'
       else
         exec 'rm -rf ' + @fullPath()

--- a/test/testRepository.coffee
+++ b/test/testRepository.coffee
@@ -1,0 +1,15 @@
+path = require 'path'
+process = require 'child_process'
+
+module.exports =
+  class TestRepository
+    constructor: (@scenario) ->
+
+    init: ->
+      process.execSync path.join __dirname, @scenario + '.sh' + ' ' + @fullPath()
+
+    fullPath: ->
+      path.join __dirname, 'test_repo'
+
+    destroy: ->
+      process.execSync 'rm -rf ' + @fullPath()


### PR DESCRIPTION
Dear Victor,

I had noticed issue (the symptoms of) #19 when trying to use atom & mercurial together and decided to try and fix it.

Unfortunately I found the development cycle for tweaking atom-plugins to be somewhat slow, so I decided to add unit-tests (okay, okay; integration-tests). 

After merging this, you should be able to run the tests by simply going:
npm install
npm test

This creates 2 hg test repositories and executes some simple tests against them. I've also manually confirmed that the ignored files are now indeed ignored by atom-hg.

Finally I've added Travis & AppVeyor yaml files that should run these tests automatically on both Windows or Linux (I do not have access to a Mac unfortunately). Basically (after merging to master) you should be able to create an account on https://travis-ci.org/ and https://ci.appveyor.com/, point them to your repo and it should 'just work' (_fingers crossed_).

You can check their status for my branch at: 
https://ci.appveyor.com/project/TomKemperNL/atom-hg
https://travis-ci.org/TomKemperNL/atom-hg

I could not add the required badges to the readme file, since you need to specify a fork & branch to display them properly (otherwise they just display the globally latest commit, which is somewhat misleading). 

Some caveats:
- I haven't done any extensive manual testing, the atom-hg plugin was't working very well for me, and now it seems to do so a little better.
- I am new to Coffeescript, Git and GitHub, some rookie mistakes are inevitable

If the pull-request is accepted, I'll happily try and fix issue #22 next.
