### PR TITLE
Fixing displaying statusses on startup

### DIFF
--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -334,7 +334,7 @@ class Repository
         pathPart = parts[1]
         if pathPart? && status?
           items.push({
-            'path': pathPart
+            'path': path.join @rootPath, pathPart
             'status': @mapHgStatus(status)
           })
 

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -24,6 +24,20 @@ describe 'In a repo with some ignored files', ->
     it 'should return getPathStatus 0', ->
       assert.equal(repo.getPathStatus(ignored_file), 0)
 
+  describe 'with a modified file', ->
+    modifiedStatus = 1024
+    modified_file = path.join testRepo.fullPath(), 'modified_file'
+
+    it 'should count status as modified', ->
+      assert.equal repo.isStatusModified(modifiedStatus), true
+
+    it 'should return status modified', ->
+      assert.equal repo.isPathModified(modified_file), true
+
+    it 'should return cached status modified', ->
+      repo.refreshStatus().then ->
+        assert.equal repo.getCachedPathStatus(modified_file), modifiedStatus
+
   describe 'with a tracked file', ->
     clean_file = path.join testRepo.fullPath(), 'clean_file'
     it 'should return isPathIgnored false', ->


### PR DESCRIPTION
This should fix #22. 

Turns out it was the simple matter that atom was passing absolute paths, and the cache contained relative paths.

I changed the cache to contain absolute paths, just like in the ignore-cache.
