### PR TITLE
Performance pr

### DIFF
--- a/lib/hg-repository.coffee
+++ b/lib/hg-repository.coffee
@@ -420,9 +420,8 @@ class HgRepository
   # Refreshes the current hg status in an outside process and asynchronously
   # updates the relevant properties.
   refreshStatus: ->
-    new Promise((resolve, reject) =>
-      @cachedIgnoreStatuses = (@slashPath ignored for ignored in @getRepo().getRecursiveIgnoreStatuses())
-
+    @getRepo().getRecursiveIgnoreStatuses().then (allIgnored) =>
+      @cachedIgnoreStatuses = (@slashPath ignored for ignored in allIgnored)
       statusesDidChange = false
       if @getRepo().checkRepositoryHasChanged()
         @statuses = {}
@@ -438,5 +437,3 @@ class HgRepository
           statusesDidChange = true
 
       if statusesDidChange then @emitter.emit 'did-change-statuses'
-      resolve()
-    )

--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -315,7 +315,7 @@ class Repository
       return null
 
   getRecursiveIgnoreStatuses: () ->
-    @hgCommandAsync(['status', @rootPath, "-A"]).then (files) =>
+    @hgCommandAsync(['status', @rootPath, "-i"]).then (files) =>
       items = []
       entries = files.split('\n')
       if entries

--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -2,7 +2,7 @@ fs = require 'fs'
 path = require 'path'
 util = require 'util'
 urlParser = require 'url'
-{spawnSync} = require 'child_process'
+{spawnSync, exec} = require 'child_process'
 diffLib = require 'jsdifflib'
 
 ###
@@ -259,6 +259,30 @@ class Repository
       throw new Error('Error trying to execute Mercurial binary with params \'' + params + '\'')
     return child.stdout.toString()
 
+  hgCommandAsync: (params) ->
+    if !params
+      params = []
+    if !util.isArray(params)
+      params = [params]
+
+    return Promise.resolve('') unless @isCommandForRepo(params)
+
+    flatArgs = params.reduce (prev, next) ->
+      prev + " " + next
+    , ""
+    flatArgs = flatArgs.substring(1)
+
+    new Promise (resolve, reject) =>
+      opts =
+        cwd: @rootPath
+        maxBuffer: 50 * 1024 * 1024
+      child = exec 'hg ' + flatArgs, opts, (err, stdout, stderr) ->
+        if err
+          reject err
+        if stderr?.length > 0
+          reject stderr
+        resolve stdout
+
   handleHgError: (error) ->
     logMessage = true
     message = error.message
@@ -290,29 +314,22 @@ class Repository
       @handleHgError(error)
       return null
 
-  # Returns on success an hg-ignores array. Otherwise null.
-  # Array keys are paths, values {Number} representing the status
-  #
-  # Returns a {Array} with path and statusnumber
   getRecursiveIgnoreStatuses: () ->
-    try
-      files = @hgCommand(['status', @rootPath, "-A"])
-    catch error
-      @handleHgError(error)
-      return []
-
-    items = []
-    entries = files.split('\n')
-    if entries
-      for entry in entries
-        parts = entry.split(' ')
-        status = parts[0]
-        pathPart = parts[1]
-        if pathPart? && status?
-          if (status is 'I') # || status is '?')
-            items.push(pathPart.replace('..', ''))
-
-    (path.join @rootPath, item for item in items)
+    @hgCommandAsync(['status', @rootPath, "-A"]).then (files) =>
+      items = []
+      entries = files.split('\n')
+      if entries
+        for entry in entries
+          parts = entry.split(' ')
+          status = parts[0]
+          pathPart = parts[1]
+          if pathPart? && status?
+            if (status is 'I') # || status is '?')
+              items.push(pathPart.replace('..', ''))
+      (path.join @rootPath, item for item in items)
+    .catch (error) =>
+      @handleHgError error
+      []
 
   # Returns on success an hg-status array. Otherwise null.
   # Array keys are paths, values {Number} representing the status


### PR DESCRIPTION
My Pr #25 created a couple of new problems.

In this Pr I've moved the hg stat call to an asynchronous exec call. While this won't speed things up, it should at least not block atom while it's checking all those files.

This should fix #21. Thanks to @MikeRatcliffe for testing it. I hope it helps #27, but I doubt it.

2 small notes:

1 Now that I'm getting more familiar with the plugin code, I can also see more of the intention of some of the methods. For example, I was confused why a method called getRecursiveIgnoreStatuses wasn't actually recursive. I'm guessing the intention was to recursively walk through the repository, determining which folders are ignored and not asking hg to list the status of those folders. I'll try and implement that idea soon, which should also fix ignored folders still showing up (albeit empty).

2 I've split this weekends contributions into 3 seperate pull requests. This might create a conflict or two for you. But on the other hand, if i mash it all into one huge PR it's harder to review. Any advice?
