### PR TITLE
Dirs with spaces

### DIFF
--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -268,6 +268,9 @@ class Repository
     return Promise.resolve('') unless @isCommandForRepo(params)
 
     flatArgs = params.reduce (prev, next) ->
+      if next.indexOf? and next.indexOf(' ') != -1
+        next = "\"" + next + "\""
+
       prev + " " + next
     , ""
     flatArgs = flatArgs.substring(1)

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -46,3 +46,26 @@ describe 'In a repo with some ignored files', ->
 
   after ->
     testRepo.destroy()
+
+describe 'In a repo with spaces in the directory name', ->
+  testRepo = new TestRepository path.parse(__filename).name, 'test repo'
+  repo = null
+  before ->
+    testRepo.init()
+
+  beforeEach ->
+    repo = new HgRepository testRepo.fullPath()
+
+  ###
+  Currently any error in hg-stat commands is caught and console.error logged,
+  but the promise is not rejected.
+  So we're testing for this issue by side-effect,
+  ideally we would just assert the promise resolved succesfully
+  ###
+  it 'should still return isPathIgnored true', ->
+    ignored_file = path.join testRepo.fullPath(), 'ignored_file'
+    repo.refreshStatus().then ->
+      assert.equal(repo.isPathIgnored(ignored_file), true)
+
+  after ->
+    testRepo.destroy()

--- a/test/simple_repo.sh
+++ b/test/simple_repo.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-hg init $1
-cd $1
+
+hg init "$1"
+cd "$1"
 
 files=("clean_file" "modified_file" "removed_file" "missing_file")
 for f in ${files[*]}

--- a/test/testRepository.coffee
+++ b/test/testRepository.coffee
@@ -7,24 +7,30 @@ module.exports =
     isWindows = process.platform == 'win32'
     extension = if isWindows then '.ps1' else '.sh'
 
-    constructor: (@scenario) ->
+    constructor: (@scenario, @repoDir = 'test_repo') ->
 
     init: ->
       if @exists()
         @destroy()
+
+      command = undefined
+      fullScenario = path.join __dirname, @scenario + extension
       if isWindows
-        exec 'powershell -file ' + path.join __dirname, @scenario + extension + ' ' + @fullPath()
+        command = 'powershell -file ' + fullScenario + ' ' + '"' + @fullPath() + '"'
       else
-        exec path.join __dirname, @scenario + extension + ' ' + @fullPath()
+        command = fullScenario + ' ' + @fullPath()
+      exec command
 
     fullPath: ->
-      path.join __dirname, 'test_repo'
+      path.join __dirname, @repoDir
 
     exists: () ->
       fs.existsSync(@fullPath())
 
     destroy: ->
+      command = undefined
       if isWindows
-        exec 'powershell -command "remove-item -recurse -force ' + @fullPath() + '"'
+        command = 'powershell -command "remove-item -recurse -force \'' + @fullPath() + '\'"'
       else
-        exec 'rm -rf ' + @fullPath()
+        command = 'rm -rf ' + @fullPath()
+      exec command

--- a/test/testRepository.coffee
+++ b/test/testRepository.coffee
@@ -18,7 +18,7 @@ module.exports =
       if isWindows
         command = 'powershell -file ' + fullScenario + ' ' + '"' + @fullPath() + '"'
       else
-        command = fullScenario + ' ' + @fullPath()
+        command = fullScenario + ' "' + @fullPath() + '"'
       exec command
 
     fullPath: ->
@@ -32,5 +32,5 @@ module.exports =
       if isWindows
         command = 'powershell -command "remove-item -recurse -force \'' + @fullPath() + '\'"'
       else
-        command = 'rm -rf ' + @fullPath()
+        command = 'rm -rf "' + @fullPath() + '"'
       exec command


### PR DESCRIPTION
Fixes #34, which was caused by the switch from spawnSync to asynchronous exec. 

exec doesn't accept a parameter array, so I flattened the arguments manually.

I'm pretty sure there are still edge-cases we're missing, but at least this is a little bit better.
