### PR TITLE
Add an option to diff against a specific revision, defaults to '.'

### DIFF
--- a/lib/atom-hg.coffee
+++ b/lib/atom-hg.coffee
@@ -1,6 +1,12 @@
 HgRepositoryProvider = require './hg-repository-provider'
 
 module.exports =
+  config:
+    diffAgainstRevision:
+      type: 'string'
+      description: 'Revision that Mercurial will diff against.'
+      default: '.'
+
   activate: ->
     console.log 'Activating atom-hg...'
 

--- a/lib/hg-repository-provider.coffee
+++ b/lib/hg-repository-provider.coffee
@@ -28,7 +28,11 @@ module.exports =
 
       repo = @pathToRepository[repositoryPath]
       unless repo
-        repo = HgRepository.open(repositoryPath, project: @project)
+        repo = HgRepository.open repositoryPath,
+          project: @project
+          diffRevisionProvider: ->
+            atom.config.get('atom-hg.diffAgainstRevision')
+
         return null unless repo
 
         # TODO: takes first repository only

--- a/lib/hg-repository.coffee
+++ b/lib/hg-repository.coffee
@@ -18,9 +18,11 @@ class HgRepository
   # * `options` An optional {Object} with the following keys:
   #   * `refreshOnWindowFocus` A {Boolean}, `true` to refresh the index and
   #     statuses when the window is focused.
+  #   * `diffRevisionProvider` a {Function} that provides the revision to diff
+  #      against. Defaults to '.'.
   #
   # Returns a {HgRepository} instance or `null` if the repository could not be opened.
-  @open: (path, options) ->
+  @open: (path, options={}) ->
     return null unless path
     try
       new HgRepository(path, options)
@@ -28,9 +30,12 @@ class HgRepository
       null
 
   constructor: (path, options={}) ->
+    {@project, refreshOnWindowFocus, diffRevisionProvider} = options
+    diffRevisionProvider ?= -> '.'
+
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
-    @repo = HgUtils.open(path)
+    @repo = HgUtils.open(path, diffRevisionProvider)
     @shortHead = null
 
     unless @repo?
@@ -44,8 +49,6 @@ class HgRepository
 
     @cachedIgnoreStatuses = []
     @cachedHgFileContent = {}
-
-    {@project, refreshOnWindowFocus} = options
 
     refreshOnWindowFocus ?= true
     if refreshOnWindowFocus

--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -45,15 +45,13 @@ class Repository
   urlPath: null
 
   revision: null
-  diffRevisionProvider: () ->
-    return atom.config.get('atom-hg.diffAgainstRevision') if atom?
-    return '.'
+  diffRevisionProvider: null
 
   ###
   Section: Initialization and startup checks
   ###
 
-  constructor: (repoRootPath) ->
+  constructor: (repoRootPath, diffRevisionProvider) ->
     @rootPath = path.normalize(repoRootPath)
     unless fs.existsSync(@rootPath)
       return
@@ -62,6 +60,7 @@ class Repository
     unless lstat.isSymbolicLink()
       return
 
+    @diffRevisionProvider = diffRevisionProvider
     @rootPath = fs.realpathSync(@rootPath)
 
   # Checks if there is a hg binary in the os searchpath and returns the
@@ -487,31 +486,17 @@ exports.isStatusStaged = (status) ->
 # * `repositoryPath` The path {String} to the repository root directory
 #
 # Returns a new {Repository} object
-openRepository = (repositoryPath) ->
+openRepository = (repositoryPath, diffRevisionProvider) ->
   repository = new Repository(repositoryPath)
   if repository.checkBinaryAvailable() and repository.exists()
+    repository.diffRevisionProvider = diffRevisionProvider
     return repository
   else
     return null
 
 
-exports.open = (repositoryPath) ->
-  return openRepository(repositoryPath)
-
-
-openRepositoryAsync = (repositoryPath) ->
-  return new Promise((resolve, reject) ->
-    repository = new Repository(repositoryPath)
-    if repository.checkBinaryAvailable()
-      resolve(repository)
-    else
-      reject(null)
-  )
-
-
-exports.openAsync = (repositoryPath) ->
-  return openRepositoryAsync(repositoryPath).then((repo) ->
-    return repo)
+exports.open = (repositoryPath, diffRevisionProvider) ->
+  return openRepository(repositoryPath, diffRevisionProvider)
 
 # Verifies if given path is a symbolic link.
 # Returns original path or null otherwise.

--- a/lib/hg-utils.coffee
+++ b/lib/hg-utils.coffee
@@ -45,7 +45,9 @@ class Repository
   urlPath: null
 
   revision: null
-
+  diffRevisionProvider: () ->
+    return atom.config.get('atom-hg.diffAgainstRevision') if atom?
+    return '.'
 
   ###
   Section: Initialization and startup checks
@@ -323,7 +325,9 @@ class Repository
       return null
 
   getRecursiveIgnoreStatuses: () ->
-    @hgCommandAsync(['status', @rootPath, "-i"]).then (files) =>
+    revision = @diffRevisionProvider()
+    @hgCommandAsync(['status', @rootPath, "-i", "--rev", revision])
+    .then (files) =>
       items = []
       entries = files.split('\n')
       if entries
@@ -340,7 +344,8 @@ class Repository
       []
 
   getHgStatusAsync: () ->
-    @hgCommandAsync(['status', @rootPath]).then (files) =>
+    revision = @diffRevisionProvider()
+    @hgCommandAsync(['status', @rootPath, '--rev', revision]).then (files) =>
       items = []
       entries = files.split('\n')
       if entries
@@ -378,7 +383,8 @@ class Repository
     return null unless hgPath
 
     try
-      files = @hgCommand(['status', hgPath])
+      revision = @diffRevisionProvider()
+      files = @hgCommand(['status', hgPath, '--rev', revision])
     catch error
       @handleHgError(error)
       return null
@@ -427,14 +433,15 @@ class Repository
 
     return statusBitmask
 
-  # This retrieves the contents of the hgpath from the `HEAD` on success.
+  # This retrieves the contents of the hgpath from the diff revision on success.
   # Otherwise null.
   #
   # * `hgPath` The path {String}
   #
   # Returns {Promise} of a {String} with the filecontent
   getHgCatAsync: (hgPath) ->
-    params = ['cat', hgPath]
+    revision = @diffRevisionProvider()
+    params = ['cat', hgPath, '--rev', revision]
     return @hgCommandAsync(params).catch (error) =>
       if /no such file in rev/.test(error)
         return null

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -159,7 +159,6 @@ describe 'In a repo with a custom revision diff provider', ->
       expected =
         added: 9
         deleted: 0
-      console.log(repo.getDiffStats(modifiedFilePath), expected)
       assert.deepEqual(repo.getDiffStats(modifiedFilePath), expected)
       done()
 

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -158,6 +158,7 @@ describe 'In a repo with a custom revision diff provider', ->
       expected =
         added: 9
         deleted: 0
+      console.log(repo.getDiffStats(modifiedFilePath), expected)
       assert.deepEqual(repo.getDiffStats(modifiedFilePath), expected)
       done()
 

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -156,8 +156,8 @@ describe 'In a repo with a custom revision diff provider', ->
 
     repo.onDidChangeStatuses () ->
       expected =
-        added: 1
-        deleted: 8
+        added: 9
+        deleted: 0
       assert.deepEqual(repo.getDiffStats(modifiedFilePath), expected)
       done()
 

--- a/test/simple_repo.coffee
+++ b/test/simple_repo.coffee
@@ -144,7 +144,8 @@ describe 'In a repo with a custom revision diff provider', ->
     testRepo.init()
 
   beforeEach ->
-    repo = new HgRepository testRepo.fullPath(), diffRevisionProvider: -> '.^'
+    repo = new HgRepository testRepo.fullPath(), diffRevisionProvider: ->
+      'commit1'
 
   it 'should be able to diff against a provided revision', (done) ->
     modifiedFilePath = path.join testRepo.fullPath(), 'modified_file'

--- a/test/simple_repo.ps1
+++ b/test/simple_repo.ps1
@@ -9,14 +9,14 @@ set-location $args[0]
 new-item -type File "untracked_file"
 new-item -type File "ignored_file"
 
-Set-Content -Path "modified_file" -Value @"
-
-
-
-
-
-
-"@
+Set-Content -Path "modified_file" -Value @"1
+2
+3
+4
+5
+6
+7
+8"@
 hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
 
 Set-Content -Path ".hgignore" -Value @"

--- a/test/simple_repo.ps1
+++ b/test/simple_repo.ps1
@@ -20,6 +20,7 @@ Set-Content -Path "modified_file" -Value @"
 8
 "@
 hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
+hg tag -lf "commit1"
 
 Set-Content -Path ".hgignore" -Value @"
 syntax:glob

--- a/test/simple_repo.ps1
+++ b/test/simple_repo.ps1
@@ -9,13 +9,25 @@ set-location $args[0]
 new-item -type File "untracked_file"
 new-item -type File "ignored_file"
 
+Set-Content -Path "modified_file" -Value @"
+
+
+
+
+
+
+"@
+hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
+
 Set-Content -Path ".hgignore" -Value @"
 syntax:glob
 ignored_file
 "@
 hg add ".hgignore"
 
-hg commit -m "Commit 1" -u "Tester <test@test.com>"
+Set-Content -Path "modified_file" -Value "Some text."
+
+hg commit -m "Commit 2 with ignore" -u "Tester <test@test.com>"
 Set-Content -Path "modified_file" -Value "Changes!"
 hg remove "removed_file"
 Remove-Item "missing_file"

--- a/test/simple_repo.ps1
+++ b/test/simple_repo.ps1
@@ -9,14 +9,16 @@ set-location $args[0]
 new-item -type File "untracked_file"
 new-item -type File "ignored_file"
 
-Set-Content -Path "modified_file" -Value @"1
+Set-Content -Path "modified_file" -Value @"
+1
 2
 3
 4
 5
 6
 7
-8"@
+8
+"@
 hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
 
 Set-Content -Path ".hgignore" -Value @"

--- a/test/simple_repo.sh
+++ b/test/simple_repo.sh
@@ -16,6 +16,7 @@ touch "ignored_file"
 echo -e "1\n2\n3\n4\n5\n6\n7\n8">"modified_file"
 
 hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
+hg tag -lf "commit1"
 
 echo -e "syntax:glob\nignored_file">".hgignore"
 hg add ".hgignore"

--- a/test/simple_repo.sh
+++ b/test/simple_repo.sh
@@ -13,7 +13,7 @@ done
 touch "untracked_file"
 touch "ignored_file"
 
-echo -e "\n\n\n\n\n\n\n">"modified_file"
+echo -e "1\n2\n3\n4\n5\n6\n7\n8">"modified_file"
 
 hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
 

--- a/test/simple_repo.sh
+++ b/test/simple_repo.sh
@@ -13,10 +13,16 @@ done
 touch "untracked_file"
 touch "ignored_file"
 
+echo -e "\n\n\n\n\n\n\n">"modified_file"
+
+hg commit -m "Commit 1 without ignore" -u "Tester <test@test.com>"
+
 echo -e "syntax:glob\nignored_file">".hgignore"
 hg add ".hgignore"
 
-hg commit -m "Commit 1" -u "Tester <test@test.com>"
+echo -e "Some text.">"modified_file"
+
+hg commit -m "Commit 2 with ignore" -u "Tester <test@test.com>"
 echo -e "Changes!">"modified_file"
 hg remove "removed_file"
 rm "missing_file"


### PR DESCRIPTION
Add an option to diff against a specific revision, defaults to `.`
    
The purpose of this change is to be able to diff against a different ancestor, like `.^` the reason for this is that if I'm still working on the same revision and I plan to run `hg amend`, then I prefer to watch diffs against `.^` or another tag instead.
    
Fixes victor-torres/atom-hg#39
